### PR TITLE
Fix free-format add-words parsing for bullet/list markers

### DIFF
--- a/src/englishbot/importing/fallback_parser.py
+++ b/src/englishbot/importing/fallback_parser.py
@@ -19,6 +19,9 @@ _LATIN_RE = re.compile(r"[A-Za-z]")
 _CYRILLIC_RE = re.compile(r"[А-Яа-яЁё]")
 _TRAILING_PUNCTUATION_RE = re.compile(r"[.!?]+$")
 _LEADING_LIST_MARKER_RE = re.compile(r"^\s*\d+[\.\)]\s*")
+_GENERIC_LEADING_LIST_MARKER_RE = re.compile(
+    r"^\s*(?:[-*•▪◦●○]\s+|\[[ xX]\]\s+|\d+[\.)]\s+|[A-Za-z][\.)]\s+)+"
+)
 _PARENTHESES_PAIR_RE = re.compile(
     r"(?P<english>[A-Za-z][A-Za-z0-9'’/\\ -]*[A-Za-z0-9'’/\\-]|[A-Za-z])\s*"
     r"\((?P<translation>[^()]+)\)"
@@ -87,7 +90,7 @@ class TemplateLessonFallbackParser:
 
 
 def _parse_simple_line(line: str) -> list[ExtractedVocabularyItemDraft]:
-    stripped = line.strip()
+    stripped = _strip_leading_list_markers(line)
     if not stripped:
         return []
     parsed_parentheses_items = _parse_parentheses_pair_line(stripped)
@@ -180,3 +183,7 @@ def _looks_like_supported_pair(*, english_word: str, translation: str) -> bool:
 def _normalize_fallback_token(value: str) -> str:
     normalized = " ".join(value.split()).strip()
     return _TRAILING_PUNCTUATION_RE.sub("", normalized).strip()
+
+
+def _strip_leading_list_markers(value: str) -> str:
+    return _GENERIC_LEADING_LIST_MARKER_RE.sub("", value).strip()

--- a/src/englishbot/presentation/add_words_text.py
+++ b/src/englishbot/presentation/add_words_text.py
@@ -9,6 +9,10 @@ from englishbot.importing.models import (
 )
 from englishbot.text_variants import expand_aligned_slash_variants
 
+_LEADING_LIST_MARKER_RE = re.compile(
+    r"^\s*(?:[-*•▪◦●○]\s+|\[[ xX]\]\s+|\d+[\.)]\s+|[A-Za-z][\.)]\s+)+"
+)
+
 
 def format_draft_preview(result: ImportLessonResult) -> str:
     draft = result.draft
@@ -133,12 +137,11 @@ def should_ignore_edited_draft_line(line: str) -> bool:
         normalized_line == "draft preview"
         or normalized_line.startswith("items:")
         or normalized_line.startswith("validation errors:")
-        or normalized_line.startswith("- ")
     )
 
 
 def parse_edited_vocabulary_line(line: str) -> tuple[str, str] | None:
-    normalized_line = re.sub(r"^\d+\.\s*", "", line).strip()
+    normalized_line = _LEADING_LIST_MARKER_RE.sub("", line).strip()
     if not normalized_line:
         return None
     for separator in (":", "|", "—", " - ", " – "):

--- a/tests/test_bot_edit_text.py
+++ b/tests/test_bot_edit_text.py
@@ -76,6 +76,23 @@ def test_parse_edited_draft_text_strips_leading_number_from_new_items_source_fra
     ]
 
 
+def test_parse_edited_draft_text_accepts_bullet_markers_for_new_items() -> None:
+    parsed = parse_edited_draft_text(
+        "Topic: Birthday\nLesson: -\n\n- Birthday boy — именинник",
+        previous_draft=LessonExtractionDraft(
+            topic_title="Birthday",
+            lesson_title=None,
+            vocabulary_items=[],
+        ),
+    )
+
+    assert [item.english_word for item in parsed.vocabulary_items] == ["Birthday boy"]
+    assert [item.translation for item in parsed.vocabulary_items] == ["именинник"]
+    assert [item.source_fragment for item in parsed.vocabulary_items] == [
+        "Birthday boy — именинник"
+    ]
+
+
 def test_parse_edited_draft_text_ignores_preview_metadata_lines() -> None:
     parsed = parse_edited_draft_text(
         (

--- a/tests/test_lesson_import_pipeline.py
+++ b/tests/test_lesson_import_pipeline.py
@@ -284,6 +284,25 @@ def test_ai_unavailable_fallback_strips_leading_numbers_from_initial_raw_input()
     ]
 
 
+def test_ai_unavailable_fallback_strips_bullet_markers_from_initial_raw_input() -> None:
+    pipeline = LessonImportPipeline(
+        smart_parser=_FakeSmartParser(SmartParseUnavailable(detail="health check failed")),
+        fallback_parser=TemplateLessonFallbackParser(),
+        validator=LessonExtractionValidator(),
+        canonicalizer=DraftToContentPackCanonicalizer(),
+        writer=JsonContentPackWriter(),
+    )
+
+    result = pipeline.extract_draft(raw_text="Birthday\n\n- Birthday boy — именинник")
+
+    assert result.validation.is_valid is True
+    assert [item.english_word for item in result.draft.vocabulary_items] == ["Birthday boy"]
+    assert [item.translation for item in result.draft.vocabulary_items] == ["именинник"]
+    assert [item.source_fragment for item in result.draft.vocabulary_items] == [
+        "Birthday boy — именинник"
+    ]
+
+
 def test_ai_unavailable_fallback_splits_slash_synonyms_in_preview_draft() -> None:
     pipeline = LessonImportPipeline(
         smart_parser=_FakeSmartParser(SmartParseUnavailable(detail="health check failed")),


### PR DESCRIPTION
### Motivation
- The add-words free-text flow was silently skipping lines that start with common list or checklist markers, causing user-submitted bullet lists to be ignored during draft extraction or manual draft edits.

### Description
- Strip common leading list/checklist markers before parsing pairs by adding `_GENERIC_LEADING_LIST_MARKER_RE` and `_strip_leading_list_markers` in `src/englishbot/importing/fallback_parser.py` so fallback parsing accepts bullet/list lines.
- Improve draft-edit parsing by using the same leading-marker regex in `parse_edited_vocabulary_line` in `src/englishbot/presentation/add_words_text.py` so edited draft lines beginning with bullets are parsed correctly.
- Stop over-filtering preview metadata by removing the `normalized_line.startswith("- ")` check from `should_ignore_edited_draft_line` so valid bullet entries are not dropped.
- Add tests covering bullet-list input for both draft-edit parsing and fallback import in `tests/test_bot_edit_text.py` and `tests/test_lesson_import_pipeline.py`.

### Testing
- Ran `PYTHONPATH=src:. pytest -q tests/test_bot_edit_text.py tests/test_lesson_import_pipeline.py` and the suite passed (`57 passed`).
- Ran `PYTHONPATH=src:. pytest -q tests/test_bot_add_words_handler.py tests/test_add_words_scenarios.py tests/test_add_words_use_cases.py` and the suite passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e34b45fd008326bd9ff0926c93de56)